### PR TITLE
use scrollHeight instead of offsetHeight

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -21,7 +21,7 @@ export default function shave(target, maxheight, opts) {
       el.removeChild(span);
       el.textContent = replacedtext;
     }
-    if (el.offsetHeight < maxheight) return;
+    if (el.scrollHeight < maxheight) return;
     const text = el.textContent;
     let trimmedText = text;
     do {
@@ -29,7 +29,7 @@ export default function shave(target, maxheight, opts) {
       if (lastSpace < 0) break;
       trimmedText = trimmedText.substr(0, lastSpace);
       el.textContent = trimmedText;
-    } while (el.offsetHeight > maxheight);
+    } while (el.scrollHeight > maxheight);
     let k = 0;
     let diff = '';
     for (let j = 0; j < text.length; j++) {


### PR DESCRIPTION
In situations where the container has some CSS applied (`max-height: 100%`, flexbox properties and so on), the plugin was reading the `offsetHeight` and, being forced to be the right one, it didn't trimmed the text.

Reading `scrollHeight` you are reading the effective height that the text is using.