### PR TITLE
fixes early loop termination when non-truncated elements are evaluated

### DIFF
--- a/dist/shave.js
+++ b/dist/shave.js
@@ -29,13 +29,13 @@ function shave(target, maxHeight, opts) {
     }
 
     // If already short enough, we're done
-    if (el.offsetHeight < maxHeight) break;
+    if (el.offsetHeight < maxHeight) continue;
 
     var fullText = el.textContent;
     var words = fullText.split(' ');
 
     // If 0 or 1 words, we're done
-    if (words.length < 2) break;
+    if (words.length < 2) continue;
 
     // Binary search for number of words which can fit in allotted height
     var max = words.length - 1;

--- a/src/shave.js
+++ b/src/shave.js
@@ -24,13 +24,13 @@ export default function shave(target, maxHeight, opts) {
     }
 
     // If already short enough, we're done
-    if (el.offsetHeight < maxHeight) break;
+    if (el.offsetHeight < maxHeight) continue;
 
     const fullText = el.textContent;
     const words = fullText.split(' ');
 
     // If 0 or 1 words, we're done
-    if (words.length < 2) break;
+    if (words.length < 2) continue;
 
     // Binary search for number of words which can fit in allotted height
     let max = words.length - 1;


### PR DESCRIPTION
The `break` statements after evaluating elements that didn't need to be truncated terminate the loop entirely, rather than moving on to the next element in the `for()` loop. My PR switches them to `continue` statements.

This bug can be seen here, where the first paragraph was modified to be shorter: http://codepen.io/jackrugile/pen/b5bd2c21590cb060ac34f5046c5e2946/