### PR TITLE
Install as non-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@
 
 npm
 ```sh
-npm install shave --save-dev
+npm install shave --save
 ```
 bower
 ```sh
-bower install shave --save-dev
+bower install shave --save
 ```
 yarn
 ```sh
-yarn add shave --dev
+yarn add shave
 ```
 
 ## Usage


### PR DESCRIPTION
This isn't really meant as a development tool so not sure why default recommendation is to install as a dev dependency?... 😄 