### PR TITLE
Fix height check before truncate

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -40,7 +40,7 @@ export default function shave(target, maxHeight, opts) {
     el.style.maxHeight = 'none';
 
     // If already short enough, we're done
-    if (el.offsetHeight < maxHeight) {
+    if (el.offsetHeight <= maxHeight) {
       el.style.height = heightStyle;
       el.style.maxHeight = maxHeightStyle;
       continue;


### PR DESCRIPTION
Shave shouldn't truncate a text if element's height is less than or equal to the maximum height.