### PR TITLE
Use createTextNode() to avoid possible XSS

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -56,11 +56,14 @@ export default function shave (target, maxHeight, opts = {}) {
     el[textProp] = spaces ? words.slice(0, max).join(' ') : words.slice(0, max)
     el.insertAdjacentHTML('beforeend', charHtml)
     const diff = spaces ? ` ${words.slice(max).join(' ')}` : words.slice(max)
-
-    el.insertAdjacentHTML(
-      'beforeend',
-      `<span class="${classname}" style="display:none;">${diff}</span>`,
-    )
+    
+    // https://stackoverflow.com/questions/476821/is-a-dom-text-node-guaranteed-to-not-be-interpreted-as-html
+    const hiddenText = document.createTextNode(diff)
+    const wrapper = document.createElement('span')
+    wrapper.classList.add(classname)
+    wrapper.style.display = 'none'
+    wrapper.appendChild(hiddenText)
+    el.insertAdjacentElement('beforeend', wrapper)
 
     styles.height = heightStyle
     styles.maxHeight = maxHeightStyle

--- a/src/shave.js
+++ b/src/shave.js
@@ -58,12 +58,12 @@ export default function shave (target, maxHeight, opts = {}) {
     const diff = spaces ? ` ${words.slice(max).join(' ')}` : words.slice(max)
 
     // https://stackoverflow.com/questions/476821/is-a-dom-text-node-guaranteed-to-not-be-interpreted-as-html
-    const hiddenText = document.createTextNode(diff)
-    const wrapper = document.createElement('span')
-    wrapper.classList.add(classname)
-    wrapper.style.display = 'none'
-    wrapper.appendChild(hiddenText)
-    el.insertAdjacentElement('beforeend', wrapper)
+    const shavedText = document.createTextNode(diff)
+    const elWithShavedText = document.createElement('span')
+    elWithShavedText.classList.add(classname)
+    elWithShavedText.style.display = 'none'
+    elWithShavedText.appendChild(shavedText)
+    el.insertAdjacentElement('beforeend', elWithShavedText)
 
     styles.height = heightStyle
     styles.maxHeight = maxHeightStyle

--- a/src/shave.js
+++ b/src/shave.js
@@ -56,7 +56,7 @@ export default function shave (target, maxHeight, opts = {}) {
     el[textProp] = spaces ? words.slice(0, max).join(' ') : words.slice(0, max)
     el.insertAdjacentHTML('beforeend', charHtml)
     const diff = spaces ? ` ${words.slice(max).join(' ')}` : words.slice(max)
-    
+
     // https://stackoverflow.com/questions/476821/is-a-dom-text-node-guaranteed-to-not-be-interpreted-as-html
     const hiddenText = document.createTextNode(diff)
     const wrapper = document.createElement('span')


### PR DESCRIPTION
## Fixes

- Fixes XSS Issue that can be seen here: https://jsfiddle.net/32795mpy/

## Proposed Changes

- For reference: https://stackoverflow.com/questions/476821/is-a-dom-text-node-guaranteed-to-not-be-interpreted-as-html


