### PR TITLE
Added max-height string percentage parsing

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -14,6 +14,11 @@ export default function shave (target, maxHeight, opts = {}) {
     const styles = el.style
     const span = el.querySelector(`.${classname}`)
     const textProp = el.textContent === undefined ? 'innerText' : 'textContent'
+    const parsedMaxHeight = (typeof maxHeight === 'number')
+      ? maxHeight
+      : maxHeight[maxHeight.length - 1] === '%'
+        ? (parseInt(maxHeight.slice(0, maxHeight.length - 1)) / 100) * el.offsetHeight
+        : maxHeight
 
     // If element text has already been shaved
     if (span) {
@@ -49,7 +54,7 @@ export default function shave (target, maxHeight, opts = {}) {
       pivot = (min + max + 1) >> 1 // eslint-disable-line no-bitwise
       el[textProp] = spaces ? words.slice(0, pivot).join(' ') : words.slice(0, pivot)
       el.insertAdjacentHTML('beforeend', charHtml)
-      if (el.offsetHeight > maxHeight) max = spaces ? pivot - 1 : pivot - 2
+      if (el.offsetHeight > parsedMaxHeight) max = spaces ? pivot - 1 : pivot - 2
       else min = pivot
     }
 


### PR DESCRIPTION
## Proposed Changes

Adding functionality to parse string based css max-height percentages.

I tried to use this library in a project I'm working, and being able to use percentage based max-height attributes made solving problems easier. One key example was that I wanted to truncate the text to avoid overflowing the parent, so being able to just do something like:

`
shave('#something', '100%');
`

made solving this problem extremely easy.

I have no problems to fix any problems that this might bring, it would be nice to get a CR and some feedback for it!

