### PR TITLE
fix: remove usage of insertAdjacentElement

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -62,7 +62,7 @@ export default function shave (target, maxHeight, opts = {}) {
     elWithShavedText.classList.add(classname)
     elWithShavedText.style.display = 'none'
     elWithShavedText.appendChild(shavedText)
-    el.insertAdjacentElement('beforeend', elWithShavedText)
+    el.appendChild(elWithShavedText)
 
     styles.height = heightStyle
     styles.maxHeight = maxHeightStyle


### PR DESCRIPTION
## Fixes

- Fixes #169

## Proposed Changes

- Remove usage of `insertAdjacentElement` and replace it with `appendChild` instead.
  - According to MDN ([link here](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement#See_also)), `appendChild` should have the same effect as `insertAdjacentElement('beforeend', _)`
    ![image](https://user-images.githubusercontent.com/8733840/63160711-01683000-c051-11e9-8562-e8788bd3b10a.png)

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
