### PR TITLE
Do not throw when maxHeight equals 0

### DIFF
--- a/src/shave.js
+++ b/src/shave.js
@@ -1,5 +1,5 @@
 export default function shave (target, maxHeight, opts = {}) {
-  if (!maxHeight) throw Error('maxHeight is required')
+  if (typeof maxHeight === 'undefined' || isNaN(maxHeight)) throw Error('maxHeight is required')
   let els = (typeof target === 'string') ? document.querySelectorAll(target) : target
   if (!els) return
 


### PR DESCRIPTION
## Fixes

We should be able to shave all the text when giving a `0` maxHeight

## Proposed Changes

Ensure `maxHeight` is not `undefined` and is a Number.
